### PR TITLE
overall tweaks that are more suited towards heavy apns usage

### DIFF
--- a/client_conn_pool.go
+++ b/client_conn_pool.go
@@ -7,9 +7,11 @@
 package http2
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // ClientConnPool manages a pool of HTTP/2 client connections.
@@ -41,6 +43,7 @@ type clientConnPool struct {
 	dialing      map[string]*dialCall     // currently in-flight dials
 	keys         map[*ClientConn][]string
 	addConnCalls map[string]*addConnCall // in-flight addConnIfNeede calls
+	ctx          context.Context
 }
 
 func (p *clientConnPool) GetClientConn(req *http.Request, addr string) (*ClientConn, error) {
@@ -195,6 +198,26 @@ func (p *clientConnPool) addConnLocked(key string, cc *ClientConn) {
 	}
 	p.conns[key] = append(p.conns[key], cc)
 	p.keys[cc] = append(p.keys[cc], key)
+	go p.pingApple(key, cc)
+}
+
+// Keep pinging apple to keep connections alive unless
+// terminated explicitly via cancellable context
+func (p *clientConnPool) pingApple(key string, cc *ClientConn) {
+	for {
+		err := cc.Ping(p.ctx)
+		if err != nil {
+			if err.Error() != "context canceled" {
+				// Pinging error signifies a broken connection,
+				// initialize another one
+				p.mu.Lock()
+				p.getStartDialLocked(key)
+				p.mu.Unlock()
+			}
+			return
+		}
+		time.Sleep(15 * time.Second)
+	}
 }
 
 func (p *clientConnPool) MarkDead(cc *ClientConn) {

--- a/transport.go
+++ b/transport.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"errors"
@@ -101,6 +102,16 @@ type Transport struct {
 
 	connPoolOnce  sync.Once
 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
+
+	// Cancellable context function to stop all ongoing pinging
+	cancelFn      context.CancelFunc
+}
+
+// CeasePinging stops all ongoing pinging operations that keep
+// aPNS connections alive and healthy. Must be called if a client
+// won't be used anymore.
+func (t *Transport) CeasePinging() {
+	t.cancelFn()
 }
 
 func (t *Transport) maxHeaderListSize() uint32 {
@@ -136,7 +147,9 @@ func (t *Transport) initConnPool() {
 	if t.ConnPool != nil {
 		t.connPoolOrDef = t.ConnPool
 	} else {
-		t.connPoolOrDef = &clientConnPool{t: t}
+		ctx, cancelFn := context.WithCancel(context.Background())
+		t.cancelFn = cancelFn
+		t.connPoolOrDef = &clientConnPool{t: t, ctx: ctx}
 	}
 }
 
@@ -645,8 +658,11 @@ func (cc *ClientConn) canTakeNewRequestLocked() bool {
 	if cc.singleUse && cc.nextStreamID > 1 {
 		return false
 	}
+	// Create a new connection if current streams approach
+	// the max concurrent streams limit
 	return cc.goAway == nil && !cc.closed &&
-		int64(cc.nextStreamID)+int64(cc.pendingRequests) < math.MaxInt32
+		int64(cc.nextStreamID)+int64(cc.pendingRequests) < math.MaxInt32 &&
+		int64(len(cc.streams))+1 <= int64(cc.maxConcurrentStreams)
 }
 
 // onIdleTimeout is called from a time.AfterFunc goroutine. It will
@@ -1938,7 +1954,9 @@ func (rl *clientConnReadLoop) processSettings(f *SettingsFrame) error {
 		case SettingMaxFrameSize:
 			cc.maxFrameSize = s.Val
 		case SettingMaxConcurrentStreams:
-			cc.maxConcurrentStreams = s.Val
+			// Do not fill the connection's entire
+			// multiplexing limit to be on the safe side
+			cc.maxConcurrentStreams = s.Val - (s.Val/10)
 		case SettingInitialWindowSize:
 			// Values above the maximum flow-control
 			// window size of 2^31-1 MUST be treated as a


### PR DESCRIPTION
Hey @sideshow! Life got busy and it took me a while to take a look at this. However, I got some good findings:

At some point, http/2 transport became more conservative when it comes to connection pooling, specifically regarding opening new connections when `maxconcurrentstreams` is reached. See the old code and issue [here](https://github.com/golang/go/issues/13774).

The logic _used to_ open a new internal connection and add it to the pool, now it's much more liberal when deciding whether a connection can take on a new request; the answer is almost always yes.

However, what happens now is that when a request tries to use the said connection, if the number of streams are greater than the max value, it waits for its turn. See [here](https://github.com/sideshow/http2/blob/master/transport.go#L964). Go's current strategy seems to keep the number of connections in the pool at 1 for user space requests and queue them.

Today, the `maxconcurrentstreams` value sent by Apple is 1000. If you try to send 10k pushes, 1k of them will be processed immediately, and the rest 9k will wait their turn. The waiting portion counts towards the timeout limit enforced by `http.Client`, thus when you try to send a large amount through a client without some sort of limitation, latter requests are _almost guaranteed_ to hit timeouts.

I've incorporated the old approach to the new code. and the performance and stability increase is pretty significant. Timeouts are gone and speed is two-fold. On top, I've added a pinging mechanism for new connections in the pool, making them ready to use when needed in the future.

What do you have in mind as functionality? Should pinging be done internally or explicitly by the user? When do we stop pinging? Do we keep pinging until the connection is broken, or stop once it hasn't been used in a while? We also have the means to initialize as many internal connections as we want without any real payload data, should we expose this pre-warming as an API? This custom transport layer approach provides a lot of flexibility, so let's roll!